### PR TITLE
Use modern rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.17.0
+  - 1.31.0
   - stable
   - nightly
 sudo: required

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
     "Simon Sapin <simon.sapin@exyr.org>",
     "Evgeniy Reizner <razrfalcon@gmail.com>"
 ]
+edition = "2018"
 license = "MIT"
 description = "A 'DOM-like' tree implemented using reference counting"
 repository = "https://github.com/RazrFalcon/rctree"

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,0 +1,293 @@
+//! Iterators.
+
+use crate::Node;
+
+macro_rules! impl_node_iterator {
+    ($name: ident, $next: expr) => {
+        impl<T> Iterator for $name<T> {
+            type Item = Node<T>;
+
+            /// # Panics
+            ///
+            /// Panics if the node about to be yielded is currently mutably borrowed.
+            fn next(&mut self) -> Option<Self::Item> {
+                match self.0.take() {
+                    Some(node) => {
+                        self.0 = $next(&node);
+                        Some(node)
+                    }
+                    None => None
+                }
+            }
+        }
+    }
+}
+
+/// An iterator of nodes to the ancestors a given node.
+pub struct Ancestors<T>(Option<Node<T>>);
+impl_node_iterator!(Ancestors, |node: &Node<T>| node.parent());
+
+impl<T> Ancestors<T> {
+    pub(crate) fn new(node: Node<T>) -> Self {
+        Self(Some(node))
+    }
+}
+
+/// An iterator of nodes to the siblings before a given node.
+pub struct PrecedingSiblings<T>(Option<Node<T>>);
+impl_node_iterator!(PrecedingSiblings, |node: &Node<T>| node.previous_sibling());
+
+impl<T> PrecedingSiblings<T> {
+    pub(crate) fn new(node: Node<T>) -> Self {
+        Self(Some(node))
+    }
+}
+
+/// An iterator of nodes to the siblings after a given node.
+pub struct FollowingSiblings<T>(Option<Node<T>>);
+impl_node_iterator!(FollowingSiblings, |node: &Node<T>| node.next_sibling());
+
+impl<T> FollowingSiblings<T> {
+    pub(crate) fn new(node: Node<T>) -> Self {
+        Self(Some(node))
+    }
+}
+
+/// A double ended iterator of nodes to the children of a given node.
+pub struct Children<T> {
+    next: Option<Node<T>>,
+    next_back: Option<Node<T>>,
+}
+
+impl<T> Children<T> {
+    pub(crate) fn new(node: &Node<T>) -> Self {
+        Self {
+            next: node.first_child(),
+            next_back: node.last_child(),
+        }
+    }
+
+    // true if self.next_back's next sibling is self.next
+    fn finished(&self) -> bool {
+        match self.next_back {
+            Some(ref next_back) => next_back.next_sibling() == self.next,
+            _ => true,
+        }
+    }
+}
+
+impl<T> Iterator for Children<T> {
+    type Item = Node<T>;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutably borrowed.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished() {
+            return None;
+        }
+
+        match self.next.take() {
+            Some(node) => {
+                self.next = node.next_sibling();
+                Some(node)
+            }
+            None => None
+        }
+    }
+}
+
+impl<T> DoubleEndedIterator for Children<T> {
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutably borrowed.
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.finished() {
+            return None;
+        }
+
+        match self.next_back.take() {
+            Some(node) => {
+                self.next_back = node.previous_sibling();
+                Some(node)
+            }
+            None => None
+        }
+    }
+}
+
+/// An iterator of nodes to a given node and its descendants, in tree order.
+pub struct Descendants<T>(Traverse<T>);
+
+impl<T> Descendants<T> {
+    pub(crate) fn new(node: Node<T>) -> Self {
+        Self(Traverse::new(node))
+    }
+}
+
+impl<T> Iterator for Descendants<T> {
+    type Item = Node<T>;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutably borrowed.
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.0.next() {
+                Some(NodeEdge::Start(node)) => return Some(node),
+                Some(NodeEdge::End(_)) => {}
+                None => return None
+            }
+        }
+    }
+}
+
+
+/// A node type during traverse.
+#[derive(Clone, Debug)]
+pub enum NodeEdge<T> {
+    /// Indicates that start of a node that has children.
+    /// Yielded by `Traverse::next` before the node's descendants.
+    /// In HTML or XML, this corresponds to an opening tag like `<div>`
+    Start(Node<T>),
+
+    /// Indicates that end of a node that has children.
+    /// Yielded by `Traverse::next` after the node's descendants.
+    /// In HTML or XML, this corresponds to a closing tag like `</div>`
+    End(Node<T>),
+}
+
+// Implement PartialEq manually, because we do not need to require T: PartialEq
+impl<T> PartialEq for NodeEdge<T> {
+    fn eq(&self, other: &NodeEdge<T>) -> bool {
+        match (&*self, &*other) {
+            (&NodeEdge::Start(ref n1), &NodeEdge::Start(ref n2)) => *n1 == *n2,
+            (&NodeEdge::End(ref n1), &NodeEdge::End(ref n2)) => *n1 == *n2,
+            _ => false,
+        }
+    }
+}
+
+impl<T> NodeEdge<T> {
+    fn next_item(&self, root: &Node<T>) -> Option<NodeEdge<T>> {
+        match *self {
+            NodeEdge::Start(ref node) => match node.first_child() {
+                Some(first_child) => Some(NodeEdge::Start(first_child)),
+                None => Some(NodeEdge::End(node.clone())),
+            },
+            NodeEdge::End(ref node) => {
+                if *node == *root {
+                    None
+                } else {
+                    match node.next_sibling() {
+                        Some(next_sibling) => Some(NodeEdge::Start(next_sibling)),
+                        None => match node.parent() {
+                            Some(parent) => Some(NodeEdge::End(parent)),
+
+                            // `node.parent()` here can only be `None`
+                            // if the tree has been modified during iteration,
+                            // but silently stoping iteration
+                            // seems a more sensible behavior than panicking.
+                            None => None,
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    fn previous_item(&self, root: &Node<T>) -> Option<NodeEdge<T>> {
+        match *self {
+            NodeEdge::End(ref node) => match node.last_child() {
+                Some(last_child) => Some(NodeEdge::End(last_child)),
+                None => Some(NodeEdge::Start(node.clone())),
+            },
+            NodeEdge::Start(ref node) => {
+                if *node == *root {
+                    None
+                } else {
+                    match node.previous_sibling() {
+                        Some(previous_sibling) => Some(NodeEdge::End(previous_sibling)),
+                        None => match node.parent() {
+                            Some(parent) => Some(NodeEdge::Start(parent)),
+
+                            // `node.parent()` here can only be `None`
+                            // if the tree has been modified during iteration,
+                            // but silently stoping iteration
+                            // seems a more sensible behavior than panicking.
+                            None => None
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A double ended iterator of nodes to a given node and its descendants,
+/// in tree order.
+pub struct Traverse<T> {
+    root: Node<T>,
+    next: Option<NodeEdge<T>>,
+    next_back: Option<NodeEdge<T>>,
+}
+
+impl<T> Traverse<T> {
+    pub(crate) fn new(root: Node<T>) -> Self {
+        let next = Some(NodeEdge::Start(root.clone()));
+        let next_back = Some(NodeEdge::End(root.clone()));
+        Self {
+            root,
+            next,
+            next_back,
+        }
+    }
+
+    // true if self.next_back's next item is self.next
+    fn finished(&self) -> bool {
+        match self.next_back {
+            Some(ref next_back) => next_back.next_item(&self.root) == self.next,
+            _ => true,
+        }
+    }
+}
+
+impl<T> Iterator for Traverse<T> {
+    type Item = NodeEdge<T>;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutably borrowed.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished() {
+            return None;
+        }
+
+        match self.next.take() {
+            Some(item) => {
+                self.next = item.next_item(&self.root);
+                Some(item)
+            }
+            None => None
+        }
+    }
+}
+
+impl<T> DoubleEndedIterator for Traverse<T> {
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutably borrowed.
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.finished() {
+            return None;
+        }
+
+        match self.next_back.take() {
+            Some(item) => {
+                self.next_back = item.previous_item(&self.root);
+                Some(item)
+            }
+            None => None
+        }
+    }
+}

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -11,13 +11,9 @@ macro_rules! impl_node_iterator {
             ///
             /// Panics if the node about to be yielded is currently mutably borrowed.
             fn next(&mut self) -> Option<Self::Item> {
-                match self.0.take() {
-                    Some(node) => {
-                        self.0 = $next(&node);
-                        Some(node)
-                    }
-                    None => None
-                }
+                let node = self.0.take()?;
+                self.0 = $next(&node);
+                Some(node)
             }
         }
     }
@@ -87,13 +83,9 @@ impl<T> Iterator for Children<T> {
             return None;
         }
 
-        match self.next.take() {
-            Some(node) => {
-                self.next = node.next_sibling();
-                Some(node)
-            }
-            None => None
-        }
+        let node = self.next.take()?;
+        self.next = node.next_sibling();
+        Some(node)
     }
 }
 
@@ -106,13 +98,9 @@ impl<T> DoubleEndedIterator for Children<T> {
             return None;
         }
 
-        match self.next_back.take() {
-            Some(node) => {
-                self.next_back = node.previous_sibling();
-                Some(node)
-            }
-            None => None
-        }
+        let node = self.next_back.take()?;
+        self.next_back = node.previous_sibling();
+        Some(node)
     }
 }
 
@@ -263,13 +251,9 @@ impl<T> Iterator for Traverse<T> {
             return None;
         }
 
-        match self.next.take() {
-            Some(item) => {
-                self.next = item.next_item(&self.root);
-                Some(item)
-            }
-            None => None
-        }
+        let item = self.next.take()?;
+        self.next = item.next_item(&self.root);
+        Some(item)
     }
 }
 
@@ -282,12 +266,8 @@ impl<T> DoubleEndedIterator for Traverse<T> {
             return None;
         }
 
-        match self.next_back.take() {
-            Some(item) => {
-                self.next_back = item.previous_item(&self.root);
-                Some(item)
-            }
-            None => None
-        }
+        let item = self.next_back.take()?;
+        self.next_back = item.previous_item(&self.root);
+        Some(item)
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -16,7 +16,7 @@ macro_rules! impl_node_iterator {
                 Some(node)
             }
         }
-    }
+    };
 }
 
 /// An iterator of nodes to the ancestors a given node.
@@ -124,12 +124,11 @@ impl<T> Iterator for Descendants<T> {
             match self.0.next() {
                 Some(NodeEdge::Start(node)) => return Some(node),
                 Some(NodeEdge::End(_)) => {}
-                None => return None
+                None => return None,
             }
         }
     }
 }
-
 
 /// A node type during traverse.
 #[derive(Clone, Debug)]
@@ -203,8 +202,8 @@ impl<T> NodeEdge<T> {
                             // if the tree has been modified during iteration,
                             // but silently stoping iteration
                             // seems a more sensible behavior than panicking.
-                            None => None
-                        }
+                            None => None,
+                        },
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,12 @@ use std::fmt;
 use std::cell::{RefCell, Ref, RefMut};
 use std::rc::{Rc, Weak};
 
+pub use crate::iterator::{
+    Ancestors, PrecedingSiblings, FollowingSiblings, Children, Descendants, Traverse, NodeEdge
+};
+
+pub mod iterator;
+
 type Link<T> = Rc<RefCell<NodeData<T>>>;
 type WeakLink<T> = Weak<RefCell<NodeData<T>>>;
 
@@ -215,21 +221,21 @@ impl<T> Node<T> {
     ///
     /// Includes the current node.
     pub fn ancestors(&self) -> Ancestors<T> {
-        Ancestors(Some(self.clone()))
+        Ancestors::new(self.clone())
     }
 
     /// Returns an iterator of nodes to this node and the siblings before it.
     ///
     /// Includes the current node.
     pub fn preceding_siblings(&self) -> PrecedingSiblings<T> {
-        PrecedingSiblings(Some(self.clone()))
+        PrecedingSiblings::new(self.clone())
     }
 
     /// Returns an iterator of nodes to this node and the siblings after it.
     ///
     /// Includes the current node.
     pub fn following_siblings(&self) -> FollowingSiblings<T> {
-        FollowingSiblings(Some(self.clone()))
+        FollowingSiblings::new(self.clone())
     }
 
     /// Returns an iterator of nodes to this node's children.
@@ -238,10 +244,7 @@ impl<T> Node<T> {
     ///
     /// Panics if the node is currently mutably borrowed.
     pub fn children(&self) -> Children<T> {
-        Children {
-            next: self.first_child(),
-            next_back: self.last_child(),
-        }
+        Children::new(self)
     }
 
     /// Returns `true` if this node has children nodes.
@@ -257,16 +260,12 @@ impl<T> Node<T> {
     ///
     /// Includes the current node.
     pub fn descendants(&self) -> Descendants<T> {
-        Descendants(self.traverse())
+        Descendants::new(self.clone())
     }
 
     /// Returns an iterator of nodes to this node and its descendants, in tree order.
     pub fn traverse(&self) -> Traverse<T> {
-        Traverse {
-            root: self.clone(),
-            next: Some(NodeEdge::Start(self.clone())),
-            next_back: Some(NodeEdge::End(self.clone())),
-        }
+        Traverse::new(self.clone())
     }
 
     /// Detaches a node from its parent and siblings. Children are not affected.
@@ -529,266 +528,6 @@ impl<T> Drop for NodeData<T> {
 
         for mut node in stack {
             node.detach();
-        }
-    }
-}
-
-/// Iterators prelude.
-pub mod iterator {
-    pub use super::Ancestors;
-    pub use super::PrecedingSiblings;
-    pub use super::FollowingSiblings;
-    pub use super::Children;
-    pub use super::Descendants;
-    pub use super::Traverse;
-    pub use super::NodeEdge;
-}
-
-macro_rules! impl_node_iterator {
-    ($name: ident, $next: expr) => {
-        impl<T> Iterator for $name<T> {
-            type Item = Node<T>;
-
-            /// # Panics
-            ///
-            /// Panics if the node about to be yielded is currently mutably borrowed.
-            fn next(&mut self) -> Option<Self::Item> {
-                match self.0.take() {
-                    Some(node) => {
-                        self.0 = $next(&node);
-                        Some(node)
-                    }
-                    None => None
-                }
-            }
-        }
-    }
-}
-
-/// An iterator of nodes to the ancestors a given node.
-pub struct Ancestors<T>(Option<Node<T>>);
-impl_node_iterator!(Ancestors, |node: &Node<T>| node.parent());
-
-/// An iterator of nodes to the siblings before a given node.
-pub struct PrecedingSiblings<T>(Option<Node<T>>);
-impl_node_iterator!(PrecedingSiblings, |node: &Node<T>| node.previous_sibling());
-
-/// An iterator of nodes to the siblings after a given node.
-pub struct FollowingSiblings<T>(Option<Node<T>>);
-impl_node_iterator!(FollowingSiblings, |node: &Node<T>| node.next_sibling());
-
-/// A double ended iterator of nodes to the children of a given node.
-pub struct Children<T> {
-    next: Option<Node<T>>,
-    next_back: Option<Node<T>>,
-}
-
-impl<T> Children<T> {
-    // true if self.next_back's next sibling is self.next
-    fn finished(&self) -> bool {
-        match self.next_back {
-            Some(ref next_back) => next_back.next_sibling() == self.next,
-            _ => true,
-        }
-    }
-}
-
-impl<T> Iterator for Children<T> {
-    type Item = Node<T>;
-
-    /// # Panics
-    ///
-    /// Panics if the node about to be yielded is currently mutably borrowed.
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.finished() {
-            return None;
-        }
-
-        match self.next.take() {
-            Some(node) => {
-                self.next = node.next_sibling();
-                Some(node)
-            }
-            None => None
-        }
-    }
-}
-
-impl<T> DoubleEndedIterator for Children<T> {
-    /// # Panics
-    ///
-    /// Panics if the node about to be yielded is currently mutably borrowed.
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.finished() {
-            return None;
-        }
-
-        match self.next_back.take() {
-            Some(node) => {
-                self.next_back = node.previous_sibling();
-                Some(node)
-            }
-            None => None
-        }
-    }
-}
-
-/// An iterator of nodes to a given node and its descendants, in tree order.
-pub struct Descendants<T>(Traverse<T>);
-
-impl<T> Iterator for Descendants<T> {
-    type Item = Node<T>;
-
-    /// # Panics
-    ///
-    /// Panics if the node about to be yielded is currently mutably borrowed.
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.0.next() {
-                Some(NodeEdge::Start(node)) => return Some(node),
-                Some(NodeEdge::End(_)) => {}
-                None => return None
-            }
-        }
-    }
-}
-
-
-/// A node type during traverse.
-#[derive(Clone, Debug)]
-pub enum NodeEdge<T> {
-    /// Indicates that start of a node that has children.
-    /// Yielded by `Traverse::next` before the node's descendants.
-    /// In HTML or XML, this corresponds to an opening tag like `<div>`
-    Start(Node<T>),
-
-    /// Indicates that end of a node that has children.
-    /// Yielded by `Traverse::next` after the node's descendants.
-    /// In HTML or XML, this corresponds to a closing tag like `</div>`
-    End(Node<T>),
-}
-
-// Implement PartialEq manually, because we do not need to require T: PartialEq
-impl<T> PartialEq for NodeEdge<T> {
-    fn eq(&self, other: &NodeEdge<T>) -> bool {
-        match (&*self, &*other) {
-            (&NodeEdge::Start(ref n1), &NodeEdge::Start(ref n2)) => *n1 == *n2,
-            (&NodeEdge::End(ref n1), &NodeEdge::End(ref n2)) => *n1 == *n2,
-            _ => false,
-        }
-    }
-}
-
-impl<T> NodeEdge<T> {
-    fn next_item(&self, root: &Node<T>) -> Option<NodeEdge<T>> {
-        match *self {
-            NodeEdge::Start(ref node) => match node.first_child() {
-                Some(first_child) => Some(NodeEdge::Start(first_child)),
-                None => Some(NodeEdge::End(node.clone())),
-            },
-            NodeEdge::End(ref node) => {
-                if *node == *root {
-                    None
-                } else {
-                    match node.next_sibling() {
-                        Some(next_sibling) => Some(NodeEdge::Start(next_sibling)),
-                        None => match node.parent() {
-                            Some(parent) => Some(NodeEdge::End(parent)),
-
-                            // `node.parent()` here can only be `None`
-                            // if the tree has been modified during iteration,
-                            // but silently stoping iteration
-                            // seems a more sensible behavior than panicking.
-                            None => None,
-                        },
-                    }
-                }
-            }
-        }
-    }
-
-    fn previous_item(&self, root: &Node<T>) -> Option<NodeEdge<T>> {
-        match *self {
-            NodeEdge::End(ref node) => match node.last_child() {
-                Some(last_child) => Some(NodeEdge::End(last_child)),
-                None => Some(NodeEdge::Start(node.clone())),
-            },
-            NodeEdge::Start(ref node) => {
-                if *node == *root {
-                    None
-                } else {
-                    match node.previous_sibling() {
-                        Some(previous_sibling) => Some(NodeEdge::End(previous_sibling)),
-                        None => match node.parent() {
-                            Some(parent) => Some(NodeEdge::Start(parent)),
-
-                            // `node.parent()` here can only be `None`
-                            // if the tree has been modified during iteration,
-                            // but silently stoping iteration
-                            // seems a more sensible behavior than panicking.
-                            None => None
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// A double ended iterator of nodes to a given node and its descendants,
-/// in tree order.
-pub struct Traverse<T> {
-    root: Node<T>,
-    next: Option<NodeEdge<T>>,
-    next_back: Option<NodeEdge<T>>,
-}
-
-impl<T> Traverse<T> {
-    // true if self.next_back's next item is self.next
-    fn finished(&self) -> bool {
-        match self.next_back {
-            Some(ref next_back) => next_back.next_item(&self.root) == self.next,
-            _ => true,
-        }
-    }
-}
-
-impl<T> Iterator for Traverse<T> {
-    type Item = NodeEdge<T>;
-
-    /// # Panics
-    ///
-    /// Panics if the node about to be yielded is currently mutably borrowed.
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.finished() {
-            return None;
-        }
-
-        match self.next.take() {
-            Some(item) => {
-                self.next = item.next_item(&self.root);
-                Some(item)
-            }
-            None => None
-        }
-    }
-}
-
-impl<T> DoubleEndedIterator for Traverse<T> {
-    /// # Panics
-    ///
-    /// Panics if the node about to be yielded is currently mutably borrowed.
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.finished() {
-            return None;
-        }
-
-        match self.next_back.take() {
-            Some(item) => {
-                self.next_back = item.previous_item(&self.root);
-                Some(item)
-            }
-            None => None
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,13 @@ impl<T> PartialEq for Node<T> {
 }
 
 impl<T: fmt::Debug> fmt::Debug for Node<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&*self.borrow(), f)
     }
 }
 
 impl<T: fmt::Display> fmt::Display for Node<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.borrow(), f)
     }
 }
@@ -204,7 +204,7 @@ impl<T> Node<T> {
     /// # Panics
     ///
     /// Panics if the node is currently mutably borrowed.
-    pub fn borrow(&self) -> Ref<T> {
+    pub fn borrow(&self) -> Ref<'_, T> {
         Ref::map(self.0.borrow(), |v| &v.data)
     }
 
@@ -213,7 +213,7 @@ impl<T> Node<T> {
     /// # Panics
     ///
     /// Panics if the node is currently borrowed.
-    pub fn borrow_mut(&mut self) -> RefMut<T> {
+    pub fn borrow_mut(&mut self) -> RefMut<'_, T> {
         RefMut::map(self.0.borrow_mut(), |v| &mut v.data)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,17 +115,6 @@ impl<T: fmt::Display> fmt::Display for Node<T> {
     }
 }
 
-
-macro_rules! try_opt {
-    ($expr: expr) => {
-        match $expr {
-            Some(value) => value,
-            None => return None
-        }
-    }
-}
-
-
 impl<T> Node<T> {
     /// Creates a new node from its associated data.
     pub fn new(data: T) -> Node<T> {
@@ -165,7 +154,7 @@ impl<T> Node<T> {
     ///
     /// Panics if the node is currently mutably borrowed.
     pub fn parent(&self) -> Option<Node<T>> {
-        Some(Node(try_opt!(try_opt!(self.0.borrow().parent.as_ref()).upgrade())))
+        Some(Node(self.0.borrow().parent.as_ref()?.upgrade()?))
     }
 
     /// Returns a first child of this node, unless it has no child.
@@ -174,7 +163,7 @@ impl<T> Node<T> {
     ///
     /// Panics if the node is currently mutably borrowed.
     pub fn first_child(&self) -> Option<Node<T>> {
-        Some(Node(try_opt!(self.0.borrow().first_child.as_ref()).clone()))
+        Some(Node(self.0.borrow().first_child.as_ref()?.clone()))
     }
 
     /// Returns a last child of this node, unless it has no child.
@@ -183,7 +172,7 @@ impl<T> Node<T> {
     ///
     /// Panics if the node is currently mutably borrowed.
     pub fn last_child(&self) -> Option<Node<T>> {
-        Some(Node(try_opt!(try_opt!(self.0.borrow().last_child.as_ref()).upgrade())))
+        Some(Node(self.0.borrow().last_child.as_ref()?.upgrade()?))
     }
 
     /// Returns the previous sibling of this node, unless it is a first child.
@@ -192,7 +181,7 @@ impl<T> Node<T> {
     ///
     /// Panics if the node is currently mutably borrowed.
     pub fn previous_sibling(&self) -> Option<Node<T>> {
-        Some(Node(try_opt!(try_opt!(self.0.borrow().previous_sibling.as_ref()).upgrade())))
+        Some(Node(self.0.borrow().previous_sibling.as_ref()?.upgrade()?))
     }
 
     /// Returns the next sibling of this node, unless it is a last child.
@@ -201,7 +190,7 @@ impl<T> Node<T> {
     ///
     /// Panics if the node is currently mutably borrowed.
     pub fn next_sibling(&self) -> Option<Node<T>> {
-        Some(Node(try_opt!(self.0.borrow().next_sibling.as_ref()).clone()))
+        Some(Node(self.0.borrow().next_sibling.as_ref()?.clone()))
     }
 
     /// Returns a shared reference to this node's data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ impl<T> Node<T> {
         {
             let mut new_child_borrow = new_child.0.borrow_mut();
             new_child_borrow.detach();
-            new_child_borrow.root = Some(self_borrow.root.clone().unwrap_or(Rc::downgrade(&self.0)));
+            new_child_borrow.root = Some(self_borrow.root.clone().unwrap_or_else(|| Rc::downgrade(&self.0)));
             new_child_borrow.parent = Some(Rc::downgrade(&self.0));
             if let Some(last_child_weak) = self_borrow.last_child.take() {
                 if let Some(last_child_strong) = last_child_weak.upgrade() {
@@ -336,7 +336,7 @@ impl<T> Node<T> {
         {
             let mut new_child_borrow = new_child.0.borrow_mut();
             new_child_borrow.detach();
-            new_child_borrow.root = Some(self_borrow.root.clone().unwrap_or(Rc::downgrade(&self.0)));
+            new_child_borrow.root = Some(self_borrow.root.clone().unwrap_or_else(|| Rc::downgrade(&self.0)));
             new_child_borrow.parent = Some(Rc::downgrade(&self.0));
             match self_borrow.first_child.take() {
                 Some(first_child_strong) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,61 +1,57 @@
-/*!
-
-*rctree* is a "DOM-like" tree implemented using reference counting.
-
-"DOM-like" here means that data structures can be used to represent
-the parsed content of an HTML or XML document,
-like [*the* DOM](https://dom.spec.whatwg.org/) does,
-but don't necessarily have the exact same API as the DOM.
-That is:
-
-* A tree is made up of nodes.
-* Each node has zero or more *child* nodes, which are ordered.
-* Each node has a no more than one *parent*, the node that it is a *child* of.
-* A node without a *parent* is called a *root*.
-* As a consequence, each node may also have *siblings*: its *parent*'s other *children*, if any.
-* From any given node, access to its
-  parent, previous sibling, next sibling, first child, and last child (if any)
-  can take no more than *O(1)* time.
-* Each node also has data associated to it,
-  which for the purpose of this project is purely generic.
-  For an HTML document, the data would be either the text of a text node,
-  or the name and attributes of an element node.
-* The tree is mutable:
-  nodes (with their sub-trees) can be inserted or removed anywhere in the tree.
-
-The lifetime of nodes is managed through *reference counting*.
-To avoid reference cycles which would cause memory leaks, the tree is *asymmetric*:
-each node holds optional *strong references* to its next sibling and first child,
-but only optional *weak references* to its parent, previous sibling, and last child.
-
-Nodes are destroyed as soon as there is no strong reference left to them.
-The structure is such that holding a reference to the root
-is sufficient to keep the entire tree alive.
-However, if for example the only reference that exists from outside the tree
-is one that you use to traverse it,
-you will not be able to go back "up" the tree to ancestors and previous siblings after going "down",
-as those nodes will have been destroyed.
-
-Weak references to destroyed nodes are treated as if they were not set at all.
-(E.g. a node can become a root when its parent is destroyed.)
-
-Since nodes are *aliased* (have multiple references to them),
-[`RefCell`](http://doc.rust-lang.org/std/cell/index.html) is used for interior mutability.
-
-Advantages:
-
-* A single `Node` user-visible type to manipulate the tree, with methods.
-* Memory is freed as soon as it becomes unused (if parts of the tree are removed).
-
-Disadvantages:
-
-* The tree can only be accessed from the thread is was created in.
-* Any tree manipulation, including read-only traversals,
-  requires incrementing and decrementing reference counts,
-  which causes run-time overhead.
-* Nodes are allocated individually, which may cause memory fragmentation and hurt performance.
-
-*/
+//! *rctree* is a "DOM-like" tree implemented using reference counting.
+//!
+//! "DOM-like" here means that data structures can be used to represent
+//! the parsed content of an HTML or XML document,
+//! like [*the* DOM](https://dom.spec.whatwg.org/) does,
+//! but don't necessarily have the exact same API as the DOM.
+//! That is:
+//!
+//! * A tree is made up of nodes.
+//! * Each node has zero or more *child* nodes, which are ordered.
+//! * Each node has a no more than one *parent*, the node that it is a *child* of.
+//! * A node without a *parent* is called a *root*.
+//! * As a consequence, each node may also have *siblings*: its *parent*'s other *children*, if any.
+//! * From any given node, access to its
+//!   parent, previous sibling, next sibling, first child, and last child (if any)
+//!   can take no more than *O(1)* time.
+//! * Each node also has data associated to it,
+//!   which for the purpose of this project is purely generic.
+//!   For an HTML document, the data would be either the text of a text node,
+//!   or the name and attributes of an element node.
+//! * The tree is mutable:
+//!   nodes (with their sub-trees) can be inserted or removed anywhere in the tree.
+//!
+//! The lifetime of nodes is managed through *reference counting*.
+//! To avoid reference cycles which would cause memory leaks, the tree is *asymmetric*:
+//! each node holds optional *strong references* to its next sibling and first child,
+//! but only optional *weak references* to its parent, previous sibling, and last child.
+//!
+//! Nodes are destroyed as soon as there is no strong reference left to them.
+//! The structure is such that holding a reference to the root
+//! is sufficient to keep the entire tree alive.
+//! However, if for example the only reference that exists from outside the tree
+//! is one that you use to traverse it,
+//! you will not be able to go back "up" the tree to ancestors and previous siblings after going "down",
+//! as those nodes will have been destroyed.
+//!
+//! Weak references to destroyed nodes are treated as if they were not set at all.
+//! (E.g. a node can become a root when its parent is destroyed.)
+//!
+//! Since nodes are *aliased* (have multiple references to them),
+//! [`RefCell`](http://doc.rust-lang.org/std/cell/index.html) is used for interior mutability.
+//!
+//! Advantages:
+//!
+//! * A single `Node` user-visible type to manipulate the tree, with methods.
+//! * Memory is freed as soon as it becomes unused (if parts of the tree are removed).
+//!
+//! Disadvantages:
+//!
+//! * The tree can only be accessed from the thread is was created in.
+//! * Any tree manipulation, including read-only traversals,
+//!   requires incrementing and decrementing reference counts,
+//!   which causes run-time overhead.
+//! * Nodes are allocated individually, which may cause memory fragmentation and hurt performance.
 
 #![doc(html_root_url = "https://docs.rs/rctree/0.3.3")]
 #![forbid(unsafe_code)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,3 @@
-extern crate rctree;
-
 use rctree::{Node, NodeEdge};
 
 use std::fmt;
@@ -55,7 +53,7 @@ fn it_works() {
 struct TreePrinter<T>(Node<T>);
 
 impl<T: fmt::Debug> fmt::Debug for TreePrinter<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{:?}", self.0.borrow()).unwrap();
         iter_children(&self.0, 1, f);
 
@@ -63,7 +61,7 @@ impl<T: fmt::Debug> fmt::Debug for TreePrinter<T> {
     }
 }
 
-fn iter_children<T: fmt::Debug>(parent: &Node<T>, depth: usize, f: &mut fmt::Formatter) {
+fn iter_children<T: fmt::Debug>(parent: &Node<T>, depth: usize, f: &mut fmt::Formatter<'_>) {
     for child in parent.children() {
         for _ in 0..depth {
             write!(f, "    ").unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -21,34 +21,36 @@ fn it_works() {
     };
 
     {
-        let mut a = new();  // 1
-        a.append(new());  // 2
-        a.append(new());  // 3
-        a.prepend(new());  // 4
-        let mut b = new();  // 5
+        let mut a = new(); // 1
+        a.append(new()); // 2
+        a.append(new()); // 3
+        a.prepend(new()); // 4
+        let mut b = new(); // 5
         b.append(a.clone());
-        a.insert_before(new());  // 6
-        a.insert_before(new());  // 7
-        a.insert_after(new());  // 8
-        a.insert_after(new());  // 9
-        let c = new();  // 10
+        a.insert_before(new()); // 6
+        a.insert_before(new()); // 7
+        a.insert_after(new()); // 8
+        a.insert_after(new()); // 9
+        let c = new(); // 10
         b.append(c.clone());
 
         assert_eq!(drop_counter.get(), 0);
         c.previous_sibling().unwrap().detach();
         assert_eq!(drop_counter.get(), 1);
 
-        assert_eq!(b.descendants().map(|node| {
-            let borrow = node.borrow();
-            borrow.0
-        }).collect::<Vec<_>>(), [
-            5, 6, 7, 1, 4, 2, 3, 9, 10
-        ]);
+        assert_eq!(
+            b.descendants()
+                .map(|node| {
+                    let borrow = node.borrow();
+                    borrow.0
+                })
+                .collect::<Vec<_>>(),
+            [5, 6, 7, 1, 4, 2, 3, 9, 10]
+        );
     }
 
     assert_eq!(drop_counter.get(), 10);
 }
-
 
 struct TreePrinter<T>(Node<T>);
 
@@ -79,11 +81,13 @@ fn make_copy_1() {
     let node1_copy = node1.make_copy();
     node1.append(node1_copy);
 
-    assert_eq!(format!("{:?}", TreePrinter(node1)),
-"1
+    assert_eq!(
+        format!("{:?}", TreePrinter(node1)),
+        "1
     2
     1
-");
+"
+    );
 }
 
 #[test]
@@ -93,12 +97,14 @@ fn make_deep_copy_1() {
     node1.append(node2.clone());
     node2.append(node1.make_deep_copy());
 
-    assert_eq!(format!("{:?}", TreePrinter(node1)),
-"1
+    assert_eq!(
+        format!("{:?}", TreePrinter(node1)),
+        "1
     2
         1
             2
-");
+"
+    );
 }
 
 #[test]


### PR DESCRIPTION
TL;DR: tiny tiny improvements with no interface or functionality changes, but required rust version is bumped.

* Use Rust edition 2018
    + This requires rust 1.31 or later.
* Use idioms for edition 2018
    + Use `?` operator instead of `try_opt!` or `match`.
    + Apply [`cargo fix --edition-idioms`](https://doc.rust-lang.org/cargo/commands/cargo-fix.html).
* Apply formatter (rustfmt) and fix lint (clippy)
* Make the source modular
    + Iterators are now in another file and module.
    + Exported names and item paths are not changed, so this does not break compatibility.

These changes improve readability a little and make following contributions easier.
If you think Rust 1.31 (and edition 2018) is widespread enough, this would be worth doing.