### PR TITLE
Implement `Debug` for `WeakNode`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,12 @@ impl<T> Clone for WeakNode<T> {
     }
 }
 
+impl<T: fmt::Debug> fmt::Debug for WeakNode<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("(WeakNode)")
+    }
+}
+
 impl<T> WeakNode<T> {
     /// Attempts to upgrade the WeakNode to a Node.
     pub fn upgrade(&self) -> Option<Node<T>> {


### PR DESCRIPTION
`std::rc::Weak<T>` have similar `Debug` impl (simply printing "(Weak)").
This impl would be convenient when `#[derive(Debug)]`-ing types which contain `WeakNode`.